### PR TITLE
feat(devbox): auto-init submodule and add upstream:sync script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository owns the desktop product around an unmodified DeepSeek Harness c
 ## Prerequisites and setup
 
 - Use Node.js `^22.19.0` or `>=24.0.0` and the root PNPM `11.7.0` release through Corepack.
-- Initialize the pinned upstream checkout with `git submodule update --init --recursive`.
+- Initialize the pinned upstream checkout with `corepack pnpm run upstream:sync`.
 - Install root dependencies with `corepack pnpm install --frozen-lockfile`.
 
 ## Build, run, and verify

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -26,7 +26,7 @@ Plugins that follow the manifesto coexist better with other plugins and will be 
 ### Development environment
 
 ```sh
-git submodule update --init --recursive
+corepack pnpm run upstream:sync
 corepack pnpm install --frozen-lockfile
 corepack pnpm run check   # full headless gate: build, typecheck, tests, and smokes
 corepack pnpm run dev     # launch the application when a graphical session is available

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ DSH 的核心是插件。如果你写插件，请先阅读：
 ### 开发环境
 
 ```sh
-git submodule update --init --recursive
+corepack pnpm run upstream:sync
 corepack pnpm install --frozen-lockfile
 corepack pnpm run check   # 完整 headless gate：构建、类型检查、测试与冒烟
 corepack pnpm run dev     # 有图形环境时启动应用

--- a/README.en.md
+++ b/README.en.md
@@ -217,7 +217,7 @@ assets/                 ACRYL brand assets
 ### Start ACRYL
 
 ```sh
-git submodule update --init --recursive
+corepack pnpm run upstream:sync
 corepack pnpm install --frozen-lockfile
 corepack pnpm dev
 ```
@@ -299,6 +299,8 @@ current artifacts:
 The `deepseek-harness/` submodule is an independent pnpm workspace. Root wrapper
 scripts enter it before invoking its pinned pnpm release:
 
+- `corepack pnpm run upstream:sync` — runs `git submodule update --init --recursive`
+  to populate a missing checkout or sync to the current pin without moving it.
 - `corepack pnpm upstream:update` — fetches the remote default branch, verifies
   it is a fast-forward from the current clean pin, moves the Harness checkout
   to that exact commit, initializes nested submodules, and synchronizes

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: 8152e207066f828df28032abfab3cf9511360ed2
-README.en.md: 8152e207066f828df28032abfab3cf9511360ed2
+README.md: 1233b2b26bebd8887ae76587a5a45c37bf8d311f
+README.en.md: 1233b2b26bebd8887ae76587a5a45c37bf8d311f

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ assets/                 ACRYL brand assets
 ### Start ACRYL
 
 ```sh
-git submodule update --init --recursive
+corepack pnpm run upstream:sync
 corepack pnpm install --frozen-lockfile
 corepack pnpm dev
 ```
@@ -299,6 +299,8 @@ current artifacts:
 The `deepseek-harness/` submodule is an independent pnpm workspace. Root wrapper
 scripts enter it before invoking its pinned pnpm release:
 
+- `corepack pnpm run upstream:sync` — runs `git submodule update --init --recursive`
+  to populate a missing checkout or sync to the current pin without moving it.
 - `corepack pnpm upstream:update` — fetches the remote default branch, verifies
   it is a fast-forward from the current clean pin, moves the Harness checkout
   to that exact commit, initializes nested submodules, and synchronizes

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/plugins/schemas/devbox.json",
+  "packages": {
+    "nodejs_22": "latest",
+    "pnpm_11": "latest",
+    "esbuild": "latest"
+  },
+  "shell": {
+    "init_hook": [
+      "[ -d deepseek-harness/.git ] || git submodule update --init --recursive",
+      "corepack enable pnpm",
+      "corepack pnpm install --frozen-lockfile"
+    ],
+    "scripts": {
+      "sync-submodule": "corepack pnpm run upstream:sync"
+    }
+  },
+  "nixpkgs": {
+    "commit": "nixpkgs-unstable"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dist:mac-smoke": "pnpm --filter dsh-community-market run build && pnpm --filter acryl-desktop run dist:mac-smoke",
     "dist:win": "pnpm --filter dsh-community-market run build && pnpm --filter acryl-desktop run dist:win",
     "dist:win-portable": "pnpm --filter dsh-community-market run build && pnpm --filter acryl-desktop run dist:win-portable",
+    "upstream:sync": "git submodule update --init --recursive",
     "upstream:update": "node scripts/update-upstream.mjs",
     "upstream:version": "cd deepseek-harness && corepack pnpm --version",
     "upstream:install": "cd deepseek-harness && corepack pnpm install --frozen-lockfile",


### PR DESCRIPTION
## Summary / 摘要

Add a guarded submodule init to the `devbox.json` `init_hook` so the pinned `deepseek-harness` checkout populates automatically on first `devbox shell`. Add a `pnpm run upstream:sync` script as the canonical submodule sync command, reachable with or without devbox. Update `AGENTS.md`, `CONTRIBUTING.md`, `CONTRIBUTING.en.md`, `README.md`, and `README.en.md` to reference `corepack pnpm run upstream:sync` instead of the raw `git submodule update --init --recursive` command.

The `init_hook` guard is `[ -d deepseek-harness/.git ] || git submodule update --init --recursive` — it populates the submodule once on first shell, then skips the git invocation on subsequent shells to keep them cheap. A `devbox run sync-submodule` script delegates to `pnpm run upstream:sync` for explicit sync-after-pin-move.

## Related Issues / 关联 Issue

Resolves #2

## Type / 类型

- [ ] Bug fix / 问题修复
- [x] Feature / 新功能
- [x] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack pnpm run check:layout` — bilingual-docs verification passes (42 records, 84 documents consistent); `README.i18n.yaml` hashes updated to match new README blobs
- [ ] `corepack pnpm run typecheck`
- [ ] `corepack pnpm run test`
- [ ] `corepack pnpm run check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试 — `node scripts/verify-bilingual-docs.mjs` passes; `node --test scripts/bilingual-docs.test.mjs` passes (4/4)

## Release Notes / 发布说明

Contributor experience improvement: new `devbox.json` with auto-init submodule guard, new `pnpm run upstream:sync` script. No user-visible application changes.
